### PR TITLE
Fix Swift 6 concurrency regressions causing GraphQL stalls

### DIFF
--- a/Sources/SwiftGraphQL/Selection/Selection.swift
+++ b/Sources/SwiftGraphQL/Selection/Selection.swift
@@ -6,12 +6,20 @@ import GraphQL
 public final class Fields<TypeLock>: @unchecked Sendable {
 
     // Internal representation of selection.
-    private let queue = DispatchQueue(label: "com.swiftgraphql.fields")
+    private let lock = NSLock()
     private var _fields = [GraphQLField]()
 
     var fields: [GraphQLField] {
-        get { queue.sync { _fields } }
-        set { queue.sync { _fields = newValue } }
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _fields
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            _fields = newValue
+        }
     }
 
     /// State of the selection tells whether we are currently building up the query and mocking the
@@ -20,8 +28,16 @@ public final class Fields<TypeLock>: @unchecked Sendable {
     /// - NOTE: This variable should only be used by the generated code.
     private var _state: State = .selecting
     public var __state: State {
-        get { queue.sync { _state } }
-        set { queue.sync { _state = newValue } }
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _state
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            _state = newValue
+        }
     }
 
     public enum State {
@@ -58,14 +74,18 @@ public final class Fields<TypeLock>: @unchecked Sendable {
     ///
     /// - NOTE: This function should only be used by the generated code.
     public func __select(_ field: GraphQLField) {
-        fields.append(field)
+        lock.lock()
+        _fields.append(field)
+        lock.unlock()
     }
 
     /// Lets generated code add a selection to the selection set.
     ///
     /// - NOTE: This function should only be used by the generated code!
     public func __select(_ fields: [GraphQLField]) {
-        self.fields.append(contentsOf: fields)
+        lock.lock()
+        _fields.append(contentsOf: fields)
+        lock.unlock()
     }
 
     // MARK: - Decoding

--- a/Sources/SwiftGraphQLClient/Exchanges/CacheExchange.swift
+++ b/Sources/SwiftGraphQLClient/Exchanges/CacheExchange.swift
@@ -106,7 +106,9 @@ public class CacheExchange: Exchange, @unchecked Sendable {
             forwardedOps
             .handleEvents(receiveOutput: { [weak self] result in
                 guard let self = self else { return }
-                self.queue.sync {
+                let operationsToReexecute: [Operation] = self.queue.sync {
+                    var operationsToReexecute = [Operation]()
+
                     // Invalidate the cache given a mutation's response.
                     if result.operation.kind == .mutation {
                         var pendingOperations = Set<String>()
@@ -122,11 +124,11 @@ public class CacheExchange: Exchange, @unchecked Sendable {
                         // Invalidate all operations that need invalidation.
                         for opid in pendingOperations {
                             guard let cachedResult = self.resultCache[opid] else {
-                                return
+                                continue
                             }
 
                             self.resultCache.removeValue(forKey: opid)
-                            client.reexecute(operation: cachedResult.operation.with(policy: .networkOnly))
+                            operationsToReexecute.append(cachedResult.operation.with(policy: .networkOnly))
                         }
                     }
 
@@ -146,6 +148,12 @@ public class CacheExchange: Exchange, @unchecked Sendable {
                             self.operationCache[typename]!.insert(result.operation.id)
                         }
                     }
+
+                    return operationsToReexecute
+                }
+
+                for operationToReexecute in operationsToReexecute {
+                    client.reexecute(operation: operationToReexecute)
                 }
             })
             .eraseToAnyPublisher()


### PR DESCRIPTION
This PR fixes two issues introduced in the Swift 6 concurrency branch that caused severe client-side stalls when building/sending large queries.

#### Problem
- **App stalls before requests complete** (UI remains responsive, but some GraphQL queries take ~20s+).
- One root cause is a **deadlock** in `CacheExchange` during mutation-driven invalidation.
- The other is **high synchronization overhead** in `SwiftGraphQL.Fields` during selection building, which becomes very expensive for large selections.

#### Changes
1) **CacheExchange deadlock fix**
- `CacheExchange` was calling `client.reexecute(...)` *inside* `queue.sync`.
- `client.reexecute` synchronously sends into the pipeline, which can re-enter `CacheExchange` and attempt `queue.sync` again → deadlock / “never completes”.
- Fix: collect operations to reexecute inside the lock, then call `client.reexecute` **after** releasing the lock.

2) **Fields selection-building perf fix**
- `Fields` previously synchronized using `DispatchQueue.sync`, which is relatively expensive in tight loops.
- Fix: replace `DispatchQueue.sync` with an `NSLock` for `_fields` and `_state` to reduce per-field overhead in selection building (big win for large queries).

#### Results (real-world)
- Reduced worst-case stalls from ~20s to ~12s with the deadlock fix alone.
- With the `Fields` locking change, the stall matches our “good” baseline (~6s) in the iOS app.

#### Notes
- Commits are intentionally split so each fix can be reviewed independently:
  - `Fix CacheExchange reexecute deadlock`
  - `Perf: reduce Fields sync overhead with NSLock`

#### How to test
- Run any client that performs large query selections under `swift-6-concurrency`.
- Verify requests no longer hang and latency returns to expected baseline.